### PR TITLE
Don't create changeset comment foreign key on table creation

### DIFF
--- a/queries.py
+++ b/queries.py
@@ -19,7 +19,7 @@ createChangesetTable = '''CREATE EXTENSION IF NOT EXISTS hstore;
   tags hstore
 );
 CREATE TABLE osm_changeset_comment (
-  comment_changeset_id bigint not null REFERENCES osm_changeset (id),
+  comment_changeset_id bigint not null,
   comment_user_id bigint not null,
   comment_user_name varchar(255) not null,
   comment_date timestamp without time zone not null,


### PR DESCRIPTION
The primary key index doesn't exist when loading data, so the
foreign key can't be created this early.