### PR TITLE
Speed up import with batch execution

### DIFF
--- a/changesetmd.py
+++ b/changesetmd.py
@@ -102,7 +102,7 @@ class ChangesetMD():
                 for commentElement in discussion.iterchildren(tag='comment'):
                     for text in commentElement.iterchildren(tag='text'):
                        text = text.text
-                    comment = (elem.attrib['id'], ommentElement.attrib.get('uid'),  commentElement.attrib.get('user'), commentElement.attrib.get('date'), text)
+                    comment = (elem.attrib['id'], commentElement.attrib.get('uid'),  commentElement.attrib.get('user'), commentElement.attrib.get('date'), text)
                     comments.append(comment)
 
             if(doReplication):

--- a/changesetmd.py
+++ b/changesetmd.py
@@ -119,7 +119,7 @@ class ChangesetMD():
                                 elem.attrib.get('max_lat', None), elem.attrib.get('min_lon', None),  elem.attrib.get('max_lon', None), elem.attrib.get('closed_at', None),
                                      elem.attrib.get('open', None), elem.attrib.get('num_changes', None), elem.attrib.get('user', None), tags))
 
-            if((parsedCount % 10000) == 0):
+            if((parsedCount % 100000) == 0):
                 self.insertNewBatch(connection, changesets)
                 self.insertNewBatchComment(connection, comments )
                 changesets = []

--- a/changesetmd.py
+++ b/changesetmd.py
@@ -56,7 +56,7 @@ class ChangesetMD():
             sql = '''INSERT into osm_changeset
                     (id, user_id, created_at, min_lat, max_lat, min_lon, max_lon, closed_at, open, num_changes, user_name, tags, geom)
                     values (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,ST_SetSRID(ST_MakeEnvelope(%s,%s,%s,%s), 4326))'''
-            pyscopg2.extras.execute_batch(cursor, sql, data_arr)
+            psycopg2.extras.execute_batch(cursor, sql, data_arr)
             cursor.close()
         else:
             sql = '''INSERT into osm_changeset

--- a/changesetmd.py
+++ b/changesetmd.py
@@ -131,7 +131,7 @@ class ChangesetMD():
             while elem.getprevious() is not None:
                 del elem.getparent()[0]
         # Update whatever is left, then commit
-        self.isertNewBatch(connection, changesets)
+        self.insertNewBatch(connection, changesets)
         self.insertNewBatchComment(connection, comments)
         connection.commit()
         print "parsing complete"

--- a/changesetmd.py
+++ b/changesetmd.py
@@ -109,7 +109,6 @@ class ChangesetMD():
                 self.deleteExisting(connection, elem.attrib['id'])
 
             if self.createGeometry:
-                id, user_id, created_at, min_lat, max_lat, min_lon, max_lon, closed_at, open, num_changes, user_name, tags, geom
                 changesets.append((elem.attrib['id'], elem.attrib.get('uid', None),   elem.attrib['created_at'], elem.attrib.get('min_lat', None),
                                 elem.attrib.get('max_lat', None), elem.attrib.get('min_lon', None),  elem.attrib.get('max_lon', None), elem.attrib.get('closed_at', None),
                                      elem.attrib.get('open', None), elem.attrib.get('num_changes', None), elem.attrib.get('user', None), tags,elem.attrib.get('min_lon', None), elem.attrib.get('min_lat', None),


### PR DESCRIPTION
Using `pyscopg2.extras.execute_batch()` and inserting data in batches of 100,000 changesets will speed up the import. On my machine it was ~2x faster than the original method of inserting data line by line.

See documentation for [Fast execution helpers](http://initd.org/psycopg/docs/extras.html#fast-execution-helpers) in the psycopg docs.

